### PR TITLE
feat: add take() and try_take() methods to RefBox

### DIFF
--- a/src/internals.rs
+++ b/src/internals.rs
@@ -180,6 +180,22 @@ impl<T: ?Sized> RefBoxHeap<T> {
     }
 }
 
+impl<T> RefBoxHeap<T> {
+    /// Takes the data out of the heap without running the destructor.
+    ///
+    /// # Safety
+    ///
+    /// 1. Ensure there are no references to `T`.
+    /// 2. Ensure `T` is initialized.
+    /// 3. Ensure `T` is not already dropped.
+    pub(crate) unsafe fn take_data(&self) -> T {
+        // SAFETY: the caller must uphold the safety requirements
+        let value = unsafe { ptr::read(self.data.get()) };
+        self.inner.status.set(Status::Dropped);
+        value
+    }
+}
+
 /// Panics.
 ///
 /// Is unlikely to be called, so it has a 'cold' attribute for optimization.
@@ -354,6 +370,40 @@ pub(crate) unsafe fn drop_weak<T: ?Sized>(heap: NonNull<RefBoxHeap<T>>) {
         if unsafe { &(*heap.as_ptr()).inner }.status() == Status::Dropped {
             // SAFETY: there are no more references to the heap part.
             unsafe { dealloc_heap(heap) };
+        }
+    }
+}
+
+/// Called when [`RefBox::take`] is used to move the value out.
+#[inline]
+pub(crate) unsafe fn take_ref_box<T>(heap: NonNull<RefBoxHeap<T>>) -> T {
+    // SAFETY: the data of the owner is always initialized,
+    // so we can create references to the RefBoxHeap.
+
+    match unsafe { heap.as_ref() }.inner.status() {
+        Status::Available => {
+            // If there is no active borrow, we can take the data.
+            // SAFETY: the status is `Available`, so the `RefBoxHeap` is initialized, there are no
+            // other references to it, and it is not yet dropped.
+            let value = unsafe { heap.as_ref().take_data() };
+
+            // If there are no weak references, the heap
+            // part should be deallocated as well.
+            if unsafe { heap.as_ref() }.inner.weak_count() == 0 {
+                // SAFETY: there are no more references to the data.
+                unsafe { dealloc_heap(heap) };
+            }
+
+            value
+        }
+        Status::Borrowed => {
+            // Cannot take while borrowed - this is a programming error.
+            panic!("cannot take value while it is borrowed");
+        }
+        Status::DroppedWhileBorrowed | Status::Dropped => {
+            // SAFETY: if the status is `DroppedWhileBorrowed` or `Dropped` it means
+            // the RefBox was already dropped/taken which is already UB.
+            unsafe { std::hint::unreachable_unchecked() };
         }
     }
 }

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -166,7 +166,7 @@ impl<T: ?Sized> RefBoxHeap<T> {
         unsafe { &mut *self.data.get() }
     }
 
-    /// Runs the destructor of the data.
+    /// Runs the destructor of the data in place.
     ///
     /// # Safety
     ///
@@ -181,7 +181,7 @@ impl<T: ?Sized> RefBoxHeap<T> {
 }
 
 impl<T> RefBoxHeap<T> {
-    /// Takes the data out of the heap without running the destructor.
+    /// Moves the data out without running the destructor.
     ///
     /// # Safety
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,88 @@ impl<T> RefBox<T> {
         internals::new_ref_box(value)
     }
 
+    /// Takes the value out of the `RefBox`, consuming it.
+    ///
+    /// This is like [`Drop`], but instead of dropping the value, it returns it.
+    /// After calling `take()`, any [`Weak`] references will see the data as dropped
+    /// (i.e., `is_alive()` will return `false` and `try_borrow_mut()` will return
+    /// `Err(BorrowError::Dropped)`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the data is currently borrowed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use refbox::RefBox;
+    ///
+    /// let ref_box = RefBox::new(String::from("hello"));
+    /// let weak = RefBox::downgrade(&ref_box);
+    ///
+    /// // Take the value out instead of dropping it
+    /// let value = ref_box.take();
+    /// assert_eq!(value, "hello");
+    ///
+    /// // Weak references see the data as dropped
+    /// assert!(!weak.is_alive());
+    /// ```
+    pub fn take(self) -> T {
+        let ptr = self.ptr;
+        std::mem::forget(self); // Don't run normal Drop
+        // SAFETY: self is forgotten, so the data won't be double-dropped
+        unsafe { internals::take_ref_box(ptr) }
+    }
+
+    /// Tries to take the value out of the `RefBox`, consuming it.
+    ///
+    /// This is like [`take`](Self::take), but returns an error instead of panicking
+    /// if the data is currently borrowed.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(T)` if the value was successfully taken
+    /// * `Err(self)` if the data is currently borrowed (the `RefBox` is returned unchanged)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use refbox::RefBox;
+    ///
+    /// let ref_box = RefBox::new(42);
+    ///
+    /// // Take the value
+    /// let value = ref_box.try_take().unwrap();
+    /// assert_eq!(value, 42);
+    /// ```
+    ///
+    /// If the data is borrowed through a [`Weak`] reference, `try_take` returns
+    /// the `RefBox` unchanged:
+    ///
+    /// ```
+    /// use refbox::RefBox;
+    ///
+    /// let ref_box = RefBox::new(42);
+    /// let weak = RefBox::downgrade(&ref_box);
+    /// let borrow = weak.try_borrow_mut().unwrap();
+    ///
+    /// // Can't take while borrowed through weak - get the RefBox back
+    /// let ref_box = ref_box.try_take().unwrap_err();
+    ///
+    /// drop(borrow);
+    ///
+    /// // Now we can take
+    /// let value = ref_box.try_take().unwrap();
+    /// assert_eq!(value, 42);
+    /// ```
+    pub fn try_take(self) -> Result<T, Self> {
+        match self.heap().status() {
+            Status::Available => Ok(self.take()),
+            Status::Borrowed => Err(self),
+            Status::Dropped | Status::DroppedWhileBorrowed => unreachable!(),
+        }
+    }
+
     /// Creates a new `RefBox` pointer through a closure which receives a
     /// [`Weak`] pointer to the same data. Use this to create data structures
     /// that contain weak references to themselves.
@@ -1190,5 +1272,86 @@ mod tests {
     fn heap_overhead_cyclic_stable_64bit() {
         let layout = std::alloc::Layout::new::<RefBoxHeap<()>>();
         assert_eq!(layout.size(), 24);
+    }
+
+    /// Taking the value should return the value and mark as dropped for weak refs.
+    #[test]
+    fn take_returns_value() {
+        let ref_box = RefBox::new(String::from("hello"));
+        let weak = RefBox::downgrade(&ref_box);
+        assert!(weak.is_alive());
+
+        let value = ref_box.take();
+        assert_eq!(value, "hello");
+        assert!(!weak.is_alive());
+        assert!(weak.try_borrow_mut().is_err());
+    }
+
+    /// Taking the value without weak refs should deallocate immediately.
+    #[test]
+    fn take_without_weak_deallocates() {
+        let ref_box = RefBox::new(123456);
+        let value = ref_box.take();
+        assert_eq!(value, 123456);
+    }
+
+    /// Taking should run correctly with types that have Drop impls.
+    #[test]
+    fn take_does_not_run_drop() {
+        struct DropChecker(Rc<Cell<bool>>);
+        impl Drop for DropChecker {
+            fn drop(&mut self) {
+                self.0.set(true);
+            }
+        }
+
+        let drop_checker = Rc::new(Cell::new(false));
+        let ref_box = RefBox::new(DropChecker(drop_checker.clone()));
+
+        // Take should not run drop on the value
+        let taken = ref_box.take();
+        assert!(!drop_checker.get());
+
+        // Dropping the taken value should run drop
+        drop(taken);
+        assert!(drop_checker.get());
+    }
+
+    /// try_take should return Ok when not borrowed.
+    #[test]
+    fn try_take_succeeds_when_not_borrowed() {
+        let ref_box = RefBox::new(42);
+        let result = ref_box.try_take();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    /// try_take should return Err (with RefBox) when borrowed through weak.
+    #[test]
+    fn try_take_fails_when_borrowed() {
+        let ref_box = RefBox::new(42);
+        let weak = RefBox::downgrade(&ref_box);
+        let _borrow = weak.try_borrow_mut().unwrap();
+
+        let result = ref_box.try_take();
+        assert!(result.is_err());
+
+        // We got the RefBox back
+        let ref_box = result.unwrap_err();
+        drop(_borrow);
+
+        // Now we can take
+        let value = ref_box.take();
+        assert_eq!(value, 42);
+    }
+
+    /// Taking should transition status correctly.
+    #[test]
+    fn take_changes_status() {
+        let ref_box = RefBox::new(123456);
+        let weak = RefBox::downgrade(&ref_box);
+        assert_eq!(weak.status(), Status::Available);
+        ref_box.take();
+        assert_eq!(weak.status(), Status::Dropped);
     }
 }


### PR DESCRIPTION
## Summary

Add methods to move the value out of a RefBox instead of dropping it.

This is useful for data structures (like Fibonacci heaps) that need to extract values from nodes without cloning, while still having weak references to those nodes.

## New Methods

- `RefBox::take(self) -> T`: Moves the value out, consuming the RefBox. Panics if the value is currently borrowed.

- `RefBox::try_take(self) -> Result<T, Self>`: Non-panicking version that returns the RefBox unchanged if borrowed.

## Implementation

Internally, `take()` uses `ptr::read` to move the value out without running its destructor (the caller takes ownership). This differs from `drop()` which uses `drop_in_place` to destroy the value in place.

The heap allocation behavior is identical to `drop()`:
- If no weak refs exist: heap is deallocated immediately
- If weak refs exist: heap stays alive so they can observe `Status::Dropped`
- Last weak ref cleans up the heap when dropped

## Behavior

After calling `take()`, weak references see the data as dropped (same as if the RefBox was dropped normally):
- `Weak::is_alive()` returns `false`
- `Weak::try_borrow_mut()` returns `Err(BorrowError::Dropped)`

## Use Case

```rust
let ref_box = RefBox::new(String::from("hello"));
let weak = ref_box.downgrade();

// Extract value instead of dropping it
let value = ref_box.take();
assert_eq!(value, "hello");

// Weak refs see it as dropped
assert!(!weak.is_alive());
```

## Motivation

I'm building a Fibonacci heap implementation that uses RefBox for nodes. During `pop()`, I need to extract the item and priority from a node to return them. Currently this requires:
1. Wrapping fields in `Option<T>` to allow `.take()`
2. This adds 8-16 bytes per node, negating RefBox's memory savings

With this PR, the extraction becomes natural:
```rust
let node_rb: RefBox<Node<T, P>> = ...;
let node = node_rb.take();  // Move node out
(node.priority, node.item)  // Return fields
```

## Test plan

- [x] All existing tests pass
- [x] Added 6 new tests for take() behavior
- [x] Miri passes with no undefined behavior or memory leaks

🤖 Generated with [Claude Code](https://claude.ai/code)  (with extensive human direction and review)